### PR TITLE
fix:tokenizer cursor was not restored after string literal tokenizing failed

### DIFF
--- a/tokenizer/Cargo.toml
+++ b/tokenizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lua_tokenizer"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "tokenizer for lua language"

--- a/tokenizer/src/lib.rs
+++ b/tokenizer/src/lib.rs
@@ -301,6 +301,7 @@ impl<'a> Tokenizer<'a> {
             // decimals
             if let Some(b'0'..=b'9') = self.peek() {
             } else {
+                self.set_cursor(i0);
                 return Ok(None);
             }
 
@@ -768,6 +769,7 @@ impl<'a> Tokenizer<'a> {
                     };
                     Ok(Some(token))
                 } else {
+                    self.set_cursor(i0);
                     Ok(None)
                 }
             }


### PR DESCRIPTION
For #1.