### PR TITLE
fixed string literals to hold `Vec<u8>` instead of `String` for invalid unicode code point

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ lua syntax parser & interpreter in Rust
       - stack offset of local variables
       - scope checking for `return`, `break`, `goto`, `label`, ...
       - split function definition into separated Chunks
- - `lua_ir` : generate IRs from enhanced AST, and run on virtual machine.
+ - `lua_ir` : generate IRs from enhanced AST, and run on virtual machine (WIP)
 
 ## Cargo Features
  - `32bit`: use 32bit integer and float for `lua numeric` type

--- a/exec/Cargo.toml
+++ b/exec/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "exec"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]
-lua_parser = { version = "0.4.0", path = "../parser", features = ["diag"] }
-lua_semantics = { version = "0.2.0", path = "../semantics", features = [
+lua_parser = { version = "0.5.0", path = "../parser", features = ["diag"] }
+lua_semantics = { version = "0.3.0", path = "../semantics", features = [
   "diag",
 ] }
-lua_ir = { version = "0.2.0", path = "../lua_ir" }
+lua_ir = { version = "0.3.0", path = "../lua_ir" }
 codespan-reporting = { version = "0.11" }
 
 [features]

--- a/lua_ir/Cargo.toml
+++ b/lua_ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lua_ir"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "ir generation for lua_semantics crate"
@@ -10,5 +10,5 @@ keywords = ["parser", "lua", "glr"]
 categories = ["parsing"]
 
 [dependencies]
-lua_tokenizer = { version = "0.1.0", path = "../tokenizer" }
-lua_semantics = { version = "0.2.0", path = "../semantics" }
+lua_tokenizer = { version = "0.2.0", path = "../tokenizer" }
+lua_semantics = { version = "0.3.0", path = "../semantics" }

--- a/lua_ir/src/context.rs
+++ b/lua_ir/src/context.rs
@@ -233,7 +233,7 @@ impl Context {
             self.emit_expression_nil(Some(expected - 1));
         }
     }
-    fn emit_expression_string(&mut self, value: String, expected: Option<usize>) {
+    fn emit_expression_string(&mut self, value: Vec<u8>, expected: Option<usize>) {
         self.instructions.push(Instruction::String(value));
         if let Some(expected) = expected {
             self.emit_expression_nil(Some(expected - 1));
@@ -543,7 +543,8 @@ impl Context {
         if let Some(method) = expr.method {
             self.emit_expression(*expr.prefix, Some(1));
             self.instructions.push(Instruction::Clone);
-            self.instructions.push(Instruction::String(method));
+            self.instructions
+                .push(Instruction::String(method.into_bytes()));
             self.instructions.push(Instruction::TableIndex);
             self.instructions.push(Instruction::Swap);
         } else {

--- a/lua_ir/src/instruction.rs
+++ b/lua_ir/src/instruction.rs
@@ -36,7 +36,7 @@ pub enum Instruction {
     /// push int or float
     Numeric(IntOrFloat),
     /// push string
-    String(String),
+    String(Vec<u8>),
 
     /// push _G
     GetGlobal,

--- a/lua_ir/src/luaval.rs
+++ b/lua_ir/src/luaval.rs
@@ -55,7 +55,7 @@ pub enum LuaValue {
     Boolean(bool),
     Int(IntType),
     Float(FloatType),
-    String(String),
+    String(Vec<u8>),
     Table(Rc<RefCell<LuaTable>>),
     Function(LuaFunction),
     UserData(LuaUserData),
@@ -69,7 +69,7 @@ impl std::fmt::Display for LuaValue {
             LuaValue::Boolean(b) => write!(f, "{}", b),
             LuaValue::Int(n) => write!(f, "{}", n),
             LuaValue::Float(n) => write!(f, "{}", n),
-            LuaValue::String(s) => write!(f, "{}", s),
+            LuaValue::String(s) => write!(f, "{}", String::from_utf8_lossy(s)),
             LuaValue::Table(t) => {
                 write!(f, "table {:p}", Rc::as_ptr(t))
             }
@@ -317,7 +317,7 @@ impl LuaValue {
     pub fn concat(&self, other: &LuaValue) -> Result<LuaValue, RuntimeError> {
         // @TODO
         let str = format!("{}{}", self, other);
-        Ok(LuaValue::String(str))
+        unimplemented!("concat: {}", str);
     }
     pub fn not(&self) -> LuaValue {
         LuaValue::Boolean(!self.to_bool())
@@ -354,7 +354,7 @@ impl LuaValue {
             LuaValue::Boolean(b) => b.to_string(),
             LuaValue::Int(n) => n.to_string(),
             LuaValue::Float(n) => n.to_string(),
-            LuaValue::String(s) => format!("\"{}\"", s),
+            LuaValue::String(s) => format!("\"{}\"", String::from_utf8_lossy(s)),
             LuaValue::Table(_) => "table".to_string(),
             LuaValue::Function(_) => "function".to_string(),
             LuaValue::UserData(_) => "userdata".to_string(),
@@ -391,12 +391,12 @@ impl From<FloatType> for LuaValue {
 }
 impl From<String> for LuaValue {
     fn from(s: String) -> Self {
-        LuaValue::String(s)
+        LuaValue::String(s.into_bytes())
     }
 }
 impl From<&str> for LuaValue {
     fn from(s: &str) -> Self {
-        LuaValue::String(s.to_string())
+        LuaValue::String(s.bytes().collect())
     }
 }
 impl From<LuaTable> for LuaValue {

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lua_parser"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "syntax parser for lua language"
@@ -11,7 +11,7 @@ categories = ["parsing"]
 
 [dependencies]
 rusty_lr = { version = "3.2.0", features = ["fxhash"] }
-lua_tokenizer = { version = "0.1.0", path = "../tokenizer" }
+lua_tokenizer = { version = "0.2.0", path = "../tokenizer" }
 codespan-reporting = { version = "0.11", optional = true }
 
 [features]

--- a/parser/src/expression/literal.rs
+++ b/parser/src/expression/literal.rs
@@ -1,6 +1,5 @@
 use crate::IntOrFloat;
 use crate::Span;
-use crate::SpannedString;
 use crate::Token;
 use lua_tokenizer::TokenType;
 
@@ -50,11 +49,11 @@ impl From<Token> for ExprNumeric {
 /// lua string literal value
 #[derive(Clone, Debug)]
 pub struct ExprString {
-    pub value: String,
+    pub value: Vec<u8>,
     pub span: Span,
 }
 impl ExprString {
-    pub fn new(value: String, span: Span) -> Self {
+    pub fn new(value: Vec<u8>, span: Span) -> Self {
         Self { value, span }
     }
     /// get the span of the string literal
@@ -66,14 +65,9 @@ impl From<Token> for ExprString {
     fn from(t: Token) -> Self {
         match t.token_type {
             TokenType::String(s) => Self::new(s, t.span),
-            TokenType::Ident(s) => Self::new(s, t.span),
+            TokenType::Ident(s) => Self::new(s.into_bytes(), t.span),
             _ => unreachable!(),
         }
-    }
-}
-impl From<SpannedString> for ExprString {
-    fn from(s: SpannedString) -> Self {
-        Self::new(s.string, s.span)
     }
 }
 

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -25,7 +25,7 @@ use crate::ParseError;
 
 %token ident Token::new_type(TokenType::Ident("".to_string()));
 
-%token string_literal Token::new_type(TokenType::String("".to_string()));
+%token string_literal Token::new_type(TokenType::String(vec![]));
 %token numeric_literal Token::new_type(TokenType::Numeric(IntOrFloat::Int(0)));
 %token nil Token::new_type(TokenType::Nil);
 %token bool_ Token::new_type(TokenType::Bool(false));

--- a/parser/src/parser_expanded.rs
+++ b/parser/src/parser_expanded.rs
@@ -3399,7 +3399,7 @@ impl ChunkParser {
     pub fn new() -> Self {
         let __rustylr_terminals: Vec<Token> = vec![
             Token::new_type(TokenType::Ident("".to_string())),
-            Token::new_type(TokenType::String("".to_string())),
+            Token::new_type(TokenType::String(vec![])),
             Token::new_type(TokenType::Numeric(IntOrFloat::Int(0))),
             Token::new_type(TokenType::Nil),
             Token::new_type(TokenType::Bool(false)),

--- a/semantics/Cargo.toml
+++ b/semantics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lua_semantics"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "semantic analysis and enhanced AST converter for lua_parser crate"
@@ -10,7 +10,7 @@ keywords = ["parser", "lua", "glr"]
 categories = ["parsing"]
 
 [dependencies]
-lua_parser = { version = "0.4.0", path = "../parser" }
+lua_parser = { version = "0.5.0", path = "../parser" }
 codespan-reporting = { version = "0.11", optional = true }
 
 [features]

--- a/semantics/src/expression/mod.rs
+++ b/semantics/src/expression/mod.rs
@@ -17,7 +17,7 @@ pub enum Expression {
     Nil,
     Boolean(bool),
     Numeric(IntOrFloat),
-    String(String),
+    String(Vec<u8>),
 
     /// load from stack
     LocalVariable(ExprLocalVariable),
@@ -66,9 +66,14 @@ impl From<FloatType> for Expression {
         Expression::Numeric(value.into())
     }
 }
+impl From<Vec<u8>> for Expression {
+    fn from(value: Vec<u8>) -> Self {
+        Expression::String(value)
+    }
+}
 impl From<String> for Expression {
     fn from(value: String) -> Self {
-        Expression::String(value)
+        Expression::String(value.into_bytes())
     }
 }
 

--- a/tokenizer/Cargo.toml
+++ b/tokenizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lua_tokenizer"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "tokenizer for lua language"

--- a/tokenizer/src/lib.rs
+++ b/tokenizer/src/lib.rs
@@ -2,7 +2,7 @@
 //! ```rust
 //! let source = " <source code here> ";
 //!
-//! let tokenizer = Tokenizer::new(source);
+//! let tokenizer = lua_tokenizer::Tokenizer::new(source);
 //! // tokenizer itself is a lazy iterator.
 //! for token in tokenizer {
 //!     match token {
@@ -417,21 +417,12 @@ impl<'a> Tokenizer<'a> {
         &mut self,
         delim: u8,
         start: usize,
-    ) -> Result<String, TokenizeError> {
+    ) -> Result<Vec<u8>, TokenizeError> {
         let mut s = Vec::<u8>::new();
         while let Some(ch) = self.peek() {
             if ch == delim {
                 self.advance();
-                match String::from_utf8(s) {
-                    Ok(s) => return Ok(s),
-                    Err(e) => {
-                        return Err(TokenizeError::InvalidUtf8 {
-                            start,
-                            end: self.byte_offset,
-                            error: e,
-                        });
-                    }
-                }
+                return Ok(s);
             }
             match ch {
                 b'\\' => {
@@ -697,7 +688,7 @@ impl<'a> Tokenizer<'a> {
         &mut self,
         equal_count: usize,
         start: usize,
-    ) -> Result<String, TokenizeError> {
+    ) -> Result<Vec<u8>, TokenizeError> {
         let mut s = Vec::<u8>::new();
         while let Some(ch) = self.peek() {
             match ch {
@@ -706,16 +697,7 @@ impl<'a> Tokenizer<'a> {
                     let cursor0 = self.get_cursor();
                     if let Some(count) = self.long_bracket(b']') {
                         if count == equal_count {
-                            match String::from_utf8(s) {
-                                Ok(s) => return Ok(s),
-                                Err(e) => {
-                                    return Err(TokenizeError::InvalidUtf8 {
-                                        start: cursor0,
-                                        end: self.byte_offset,
-                                        error: e,
-                                    });
-                                }
-                            }
+                            return Ok(s);
                         } else {
                             self.set_cursor(cursor0);
                             self.advance();

--- a/tokenizer/src/test.rs
+++ b/tokenizer/src/test.rs
@@ -70,7 +70,7 @@ mod test {
 
             assert_eq!(token.span(), Span::new(0, 6));
             if let TokenType::String(s) = token.token_type {
-                assert_eq!(s, "abcd");
+                assert_eq!(s, "abcd".as_bytes());
             } else {
                 panic!("Expected String Literal");
             }
@@ -88,7 +88,7 @@ mod test {
 
             assert_eq!(token.span().start, 0);
             if let TokenType::String(s) = token.token_type {
-                assert_eq!(s, "ab");
+                assert_eq!(s, "ab".as_bytes());
             } else {
                 panic!("Expected StringLiteral");
             }

--- a/tokenizer/src/test.rs
+++ b/tokenizer/src/test.rs
@@ -189,4 +189,22 @@ mod test {
             panic!("Expected Ok");
         }
     }
+
+    #[test]
+    fn invalid_unicode() {
+        let string = r#""a\u{11ffff}b"  x"#;
+        let mut tokenizer = Tokenizer::new(string);
+        if let Ok(Some(ret)) = tokenizer.tokenize_string() {
+            if let TokenType::String(s) = &ret.token_type {
+                println!("{:?}", s);
+                let str = String::from_utf8_lossy(s);
+                let expected = "a����b";
+                assert_eq!(str, expected);
+            } else {
+                panic!("Expected StringLiteral");
+            }
+        } else {
+            panic!("Expected Ok");
+        }
+    }
 }

--- a/tokenizer/src/tokentype.rs
+++ b/tokenizer/src/tokentype.rs
@@ -6,7 +6,7 @@ pub enum TokenType {
     Ident(String),
 
     Numeric(IntOrFloat),
-    String(String),
+    String(Vec<u8>),
     Bool(bool),
     Nil,
 
@@ -76,7 +76,7 @@ impl TokenType {
             _ => None,
         }
     }
-    pub fn into_string(self) -> Option<String> {
+    pub fn into_string(self) -> Option<Vec<u8>> {
         match self {
             Self::String(string) => Some(string),
             _ => None,
@@ -122,6 +122,7 @@ impl std::fmt::Display for TokenType {
                 write!(f, "{}", num)
             }
             Self::String(string) => {
+                let string = String::from_utf8_lossy(string);
                 write!(f, "\"{}\"", string)
             }
             Self::Bool(boolean) => {


### PR DESCRIPTION
For #3 

https://www.lua.org/manual/5.4/manual.html#3

Lua's string can hold any utf-8 encoded string, which is not restricted to valid Unicode code points.

I was using `String` internally for lua's string literal representation,
this PR fixed lua_string to hold `Vec<u8>` instead of `String`.

Additionally, removed unicode validity check for `\u{xxx}` escape sequence.